### PR TITLE
Fixed issue with saving permission created by plugin

### DIFF
--- a/app/bundles/CoreBundle/Security/Permissions/CorePermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/CorePermissions.php
@@ -215,7 +215,8 @@ class CorePermissions
                 $entity->setName(strtolower($name));
 
                 $bit   = 0;
-                $class = $this->getPermissionObject($bundle);
+		$pluginBundles = $this->getPluginBundles();
+                $class = $this->getPermissionObject($bundle, true, array_key_exists(ucfirst($bundle) . "Bundle", $pluginBundles));
 
                 foreach ($perms as $perm) {
                     //get the bit for the perm


### PR DESCRIPTION
Previously, permissions created by plugins would cause the system to error when being saved. This is due to the pluginBundle flag was not set correct for plugins
